### PR TITLE
Populate clipboard with recipe clicked in tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ When you start the program three small buttons will pop up in the top left corne
 * 'Scan' button does all the magic. Once you press it, the program will enter the scanning mode and the button will change to 'Scanning...'. It will scan your screen according to the scanning window area and will create a list of all possible recipes. After the scan completes, the button will change again to 'Hide'. Once you examine the scan result, click the 'Hide' button to hide them.
 
 You could also hold the right mouse button to drag the controls around.
+Clicking on item in the recipe tree will copy the components to your clipboard to use in-game highlighting.
 
 ### Settings
 

--- a/poe_arch_scanner.py
+++ b/poe_arch_scanner.py
@@ -449,13 +449,13 @@ class UIOverlay:
             self._highlight_items_in_inventory(inventory_items, COLOR_FG_GREEN)
 
     def _copy_tree_items_to_clipboard(self, tree):
-        OpenClipboard()
-        EmptyClipboard()
         if len(tree.components) > 0:
             search_string = '|'.join((str(x.item) for x in tree.components))
         else:
             search_string = tree.item
 
+        OpenClipboard()
+        EmptyClipboard()
         SetClipboardText('^('+search_string+')')
         CloseClipboard()
 

--- a/poe_arch_scanner.py
+++ b/poe_arch_scanner.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from configparser import ConfigParser
 
 import win32gui
+from win32clipboard import *
 
 import tkinter as tk
 from typing import Callable, Any, Tuple, List, Dict
@@ -396,6 +397,8 @@ class UIOverlay:
         self._recipe_browser_window.geometry(f'+{self._scan_results_window.winfo_x()}+{self._scan_results_window.winfo_y() + self._scan_results_window.winfo_height() + 20}')
 
         tree = self._items_map.get_subtree_for(item)
+        self._copy_tree_items_to_clipboard(tree)
+
         def draw_tree(node, row, column):
             children_column = column
             for c in node.components:
@@ -444,6 +447,17 @@ class UIOverlay:
 
         if inventory_items is not None:
             self._highlight_items_in_inventory(inventory_items, COLOR_FG_GREEN)
+
+    def _copy_tree_items_to_clipboard(self, tree):
+        OpenClipboard()
+        EmptyClipboard()
+        if len(tree.components) > 0:
+            search_string = '|'.join((str(x.item) for x in tree.components))
+        else:
+            search_string = tree.item
+
+        SetClipboardText('^('+search_string+')')
+        CloseClipboard()
 
     def _destroy_tooltip_and_clear_highlights(self, _) -> None:
         if self._tooltip_window is not None:


### PR DESCRIPTION
Your tree UI is amazing for discovery but doesn't quickly allow you to highlight all the components again after moving onto the second/third mob in a recipe chain.

My solution is to:
- Iterate over the tree for component names, or use the top-level item if no components
- Push these items to the clipboard wrapped in `^(componet_1|component_2)`:
  - Example: Clicking on `Trickster` icon copies this to my clipboard `^(Overcharged|Assassin|Echoist)`
- Hide your tree UI
- Hit `ctrl+f` and paste into the in-game filter for easy highlighting when spending the components

Thanks for making this tool, it's fantastic!