### PR TITLE
Linux Support via gtk / wnck

### DIFF
--- a/poe_arch_scanner.py
+++ b/poe_arch_scanner.py
@@ -2,8 +2,14 @@ import sys
 from dataclasses import dataclass
 from configparser import ConfigParser
 
-import win32gui
-from win32clipboard import *
+if sys.platform.startswith('win'):
+    import win32gui
+    from win32clipboard import *
+elif sys.platform.startswith('linux'):
+    import gi
+    gi.require_version('Gtk', '3.0')
+    gi.require_version('Wnck', '3.0')
+    from gi.repository import Gtk, Wnck
 
 import tkinter as tk
 from tkinter import messagebox
@@ -625,6 +631,9 @@ class Settings:
     def should_copy_recipe_to_clipboard(self) -> bool:
         return self._copy_recipe_to_clipboard
 
+def isLinux():
+    return sys.platform.startswith('linux')
+
 def show_warning(text: str) -> None:
     messagebox.showwarning('poe-archnemesis-scanner', text)
 
@@ -635,16 +644,40 @@ def show_error_and_die(text: str) -> None:
 
 def get_poe_window_info() -> PoeWindowInfo:
     info = PoeWindowInfo()
-    hwnd = win32gui.FindWindow(None, 'Path of Exile')
-    if hwnd == 0:
-        show_error_and_die('Path of Exile is not running.')
 
-    x0, y0, x1, y1 = win32gui.GetWindowRect(hwnd)
+    windowRect = [0,0,0,0]
+    clientRect = [0,0,0,0]
+
+    if isLinux():
+        screen = Wnck.Screen.get_default()
+        screen.force_update()
+
+        hwnd = None
+
+        for window in screen.get_windows():
+            if window.get_name() == 'Path of Exile':
+                hwnd = window
+
+        if hwnd:
+            windowRect = hwnd.get_geometry()
+            clientRect = hwnd.get_client_window_geometry()
+        else:
+            show_error_and_die('Path of Exile is not running.')
+    else:
+        hwnd = win32gui.FindWindow(None, 'Path of Exile')
+
+        if hwnd == 0:
+            show_error_and_die('Path of Exile is not running.')
+
+        windowRect = win32gui.GetWindowRect(hwnd)
+        clientRect = win32gui.GetClientRect(hwnd)
+
+    x0, y0, x1, y1 = windowRect
     info.x = x0
     info.y = y0
     info.width = x1 - x0
     info.height = y1 - y0
-    x0, y0, x1, y1 = win32gui.GetClientRect(hwnd)
+    x0, y0, x1, y1 = clientRect
     info.client_width = x1 - x0
     info.client_height = y1 - y0
 
@@ -676,6 +709,10 @@ def calculate_default_scale(info: PoeWindowInfo) -> float:
 # Create root as early as possible to initialize some modules (e.g. ImageTk)
 root = tk.Tk()
 root.withdraw()
+
+# Initiate GTK since we are not using Gtk.main()
+if isLinux():
+    Gtk.init([])
 
 info = get_poe_window_info()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 opencv-python==4.5.5.62
 Pillow==9.0.1
 pywin32==303
+PyGObject==3.40.1; sys_platform == 'linux'


### PR DESCRIPTION
Hi,

I mainly threw this together for myself, but though I would share in case someone was interested. This PR provides support for Linux by providing a fallback option for win32gui and its underlying window information logic. This should hopefully :crossed_fingers: work for anyone on an X environment.

Changes:
- Only import win32gui on Windows platforms
- Import GTK / Wnck on Linux platforms.
- `get_poe_window_info()` now pulls screen information from Wnck if the application is running under  Linux.

I've marked this as a Draft since its not been tested on Windows and also to gauge interest in merging.

![image](https://user-images.githubusercontent.com/761853/153759457-4adf6d9f-d58d-4c95-8559-45bc0e32cf4c.png)