### PR TITLE
replace ' ' space characters with \s to make in-game filtering work

### DIFF
--- a/src/UIOverlay.py
+++ b/src/UIOverlay.py
@@ -262,6 +262,8 @@ class UIOverlay:
         else:
             search_string = tree.item
 
+        search_string = search_string.replace(' ', '\\s')
+
         OpenClipboard()
         EmptyClipboard()
         SetClipboardText('^('+search_string+')')


### PR DESCRIPTION
The `\s` is needed in the regex to properly search for item names with a space in them.